### PR TITLE
Setup react query to use ssr

### DIFF
--- a/src/app/providers/ReactQueryProvider.tsx
+++ b/src/app/providers/ReactQueryProvider.tsx
@@ -1,10 +1,41 @@
-import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
-import { useState } from "react";
+import {
+  isServer,
+  QueryClientProvider,
+  QueryClient,
+} from "@tanstack/react-query";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime
+        // above 0 to avoid refetching immediately on the client
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    // Server: always make a new query client
+    return makeQueryClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
 
 type ReactQueryProviderProps = { children: React.ReactNode };
 
 const ReactQueryProvider = ({ children }: ReactQueryProviderProps) => {
-  const [queryClient] = useState(() => new QueryClient());
+  const queryClient = getQueryClient();
 
   return (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>


### PR DESCRIPTION
### Why is this pull request necessary?
- We want to be able to use the ssr (Server Side Rendering) on ou components (Server Components) using the react query as an async state manager for the API calls, for that we need to change the react query provider

### What changes does this pull request add?
- Setup react query provider to use ssr