### PR TITLE
Add event spots page

### DIFF
--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,0 +1,78 @@
+"use server";
+
+import { revalidateTag } from "next/cache";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export async function selectSpotAction(eventId: string, spotName: string) {
+  const cookieStore = cookies();
+
+  const spots = JSON.parse(cookieStore.get("spots")?.value ?? "[]");
+
+  spots.push(spotName);
+
+  const uniqueSpots = spots.filter(
+    (spot: string, index: number) => spots.indexOf(spot) === index
+  );
+
+  cookieStore.set("spots", JSON.stringify(uniqueSpots));
+  cookieStore.set("eventId", eventId);
+}
+
+export async function unselectSpotAction(spotName: string) {
+  const cookieStore = cookies();
+
+  const spots = JSON.parse(cookieStore.get("spots")?.value ?? "[]");
+
+  const newSpots = spots.filter((spot: string) => spot !== spotName);
+
+  cookieStore.set("spots", JSON.stringify(newSpots));
+}
+
+export async function clearSpotsAction() {
+  const cookieStore = cookies();
+
+  cookieStore.set("spots", "[]");
+  cookieStore.set("eventId", "");
+}
+
+export async function selectTicketTypeAction(ticketKind: "full" | "half") {
+  const cookieStore = cookies();
+
+  cookieStore.set("ticketKind", ticketKind);
+}
+
+export async function checkoutAction(prevState: any, {
+  cardHash,
+  email,
+}: {
+  cardHash: string;
+  email: string;
+}) {
+  const cookieStore = cookies();
+  const eventId = cookieStore.get("eventId")?.value;
+  const spots = JSON.parse(cookieStore.get("spots")?.value ?? "[]");
+  const ticketKind = cookieStore.get("ticketKind")?.value ?? "full";
+
+  const response = await fetch(`${process.env.GOLANG_API_URL}/checkout`, {
+    method: "POST",
+    body: JSON.stringify({
+      event_id: eventId,
+      card_hash: cardHash,
+      ticket_kind: ticketKind,
+      spots,
+      email,
+    }),
+    headers: {
+      "Content-Type": "application/json",
+      "apikey": process.env.GOLANG_API_TOKEN as string
+    },
+  });
+
+  if (!response.ok) {
+    return { error: "Erro ao realizar a compra" };
+  }
+  
+  revalidateTag(`events/${eventId}`);
+  redirect(`/checkout/${eventId}/success`);
+}

--- a/src/app/event/[eventId]/spots-layout/TicketKindSelect.tsx
+++ b/src/app/event/[eventId]/spots-layout/TicketKindSelect.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { selectTicketTypeAction } from "@/app/actions";
+
+export type TicketKindSelectProps = {
+  defaultValue: "full" | "half";
+  price: number;
+};
+
+export const TicketKindSelect = ({
+  defaultValue,
+  price,
+}: TicketKindSelectProps) => {
+  const formattedFullPrice = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(price);
+  const formattedHalfPrice = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(price / 2);
+  return (
+    <>
+      <label htmlFor="ticket-type">Escolha o tipo de ingresso</label>
+      <select
+        name="ticket-type"
+        id="ticket-type"
+        className="mt-2 rounded-lg bg-input px-4 py-[14px]"
+        defaultValue={defaultValue}
+        onChange={async (e) => {
+          await selectTicketTypeAction(e.target.value as any);
+        }}
+      >
+        <option value="full">Inteira - {formattedFullPrice}</option>
+        <option value="half">Meia-entrada - {formattedHalfPrice}</option>
+      </select>
+    </>
+  );
+};

--- a/src/app/event/[eventId]/spots-layout/page.tsx
+++ b/src/app/event/[eventId]/spots-layout/page.tsx
@@ -1,0 +1,158 @@
+import { dehydrate, QueryClient } from "@tanstack/react-query";
+import { cookies } from "next/headers";
+import { Title } from "../../../../components/Title/Title";
+import { SpotSeat } from "../../../../components/SpotSeat/SpotSeat";
+import { TicketKindSelect } from "./TicketKindSelect";
+import { EventImage } from "../../../../components/Event/EventImage";
+import { useFetchSpots } from "@/hooks/useFetchSpots/useFetchSpots";
+import { SpotsService } from "@/app/services/spots/SpotsService";
+
+type PageRouterProps = {
+  params: { eventId: string };
+};
+
+export async function getServerSideProps({
+  params: { eventId },
+}: PageRouterProps) {
+  const queryClient = new QueryClient();
+  const spotsService = new SpotsService(eventId);
+
+  await queryClient.prefetchQuery(spotsService.fetchSportsQuery());
+
+  return {
+    props: {
+      dehydratedState: dehydrate(queryClient),
+    },
+  };
+}
+
+const SpotsLayoutPage = ({ params: { eventId } }: PageRouterProps) => {
+  const { data } = useFetchSpots(eventId);
+  const cookieStore = cookies();
+
+  const selectedSpots = JSON.parse(cookieStore.get("spots")?.value ?? "[]");
+
+  let totalPrice = selectedSpots.length * data.event.price;
+  const ticketKind = cookieStore.get("ticketKind")?.value ?? "full";
+
+  if (ticketKind === "half") {
+    totalPrice = totalPrice / 2;
+  }
+
+  const formattedTotalPrice = new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "BRL",
+  }).format(totalPrice);
+
+  return (
+    <main className="mt-10">
+      <div className="flex w-[1176px] max-w-full flex-row flex-wrap justify-center gap-x-8 rounded-2xl bg-secondary p-4 md:justify-normal">
+        <EventImage src={data.event.imageUrl} alt={data.event.name} />
+        <div className="flex max-w-full flex-col gap-y-6">
+          <div className="flex flex-col gap-y-2 ">
+            <p className="text-sm font-semibold uppercase text-subtitle">
+              {/* SÁB, 11/05/2024 - 20h00 */}
+              {new Date(event.date).toLocaleDateString("pt-BR", {
+                weekday: "long",
+                day: "2-digit",
+                month: "2-digit",
+                year: "numeric",
+              })}
+            </p>
+            <p className="text-2xl font-semibold">{event.name}</p>
+            <p className="font-normal">{event.location}</p>
+          </div>
+          <div className="flex h-[128px] flex-wrap justify-between gap-y-5 gap-x-3">
+            <div className="flex flex-col gap-y-2">
+              <p className="font-semibold">Organizador</p>
+              <p className="text-sm font-normal">{event.organization}</p>
+            </div>
+            <div className="flex flex-col gap-y-2">
+              <p className="font-semibold">Classificação</p>
+              <p className="text-sm font-normal">{event.rating}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <Title className="mt-10">Escolha seu lugar</Title>
+      <div className="mt-6 flex flex-wrap justify-between">
+        <div className=" mb-4 flex w-full max-w-[650px] flex-col gap-y-8 rounded-2xl bg-secondary p-6">
+          <div className="rounded-2xl bg-bar py-4 text-center text-[20px] font-bold uppercase text-white">
+            Palco
+          </div>
+          <div className="md:w-full md:justify-normal">
+            {data?.spotsGroupedByRow().map(({ row, spots }) => {
+              return (
+                <div
+                  key={row}
+                  className="flex flex-row gap-3 items-center mb-3"
+                >
+                  <div className="w-4">{row}</div>
+                  <div className="ml-2 flex flex-row">
+                    {spots.map((spot) => {
+                      const isSold = spot.status === "sold";
+                      const isSelected = selectedSpots.includes(spot.name);
+
+                      return (
+                        <SpotSeat
+                          key={spot.id}
+                          spotId={spot.name}
+                          spotLabel={spot.spotLabel()}
+                          eventId={data.event.id}
+                          selected={isSelected}
+                          disabled={isSold}
+                        />
+                      );
+                    })}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+          <div className="flex w-full flex-row justify-around">
+            <div className=" flex flex-row items-center">
+              <span className="mr-1 block h-4 w-4 rounded-full bg-[#00A96E]">
+                Disponível
+              </span>
+            </div>
+            <div className=" flex flex-row items-center">
+              <span className="mr-1 block h-4 w-4 rounded-full bg-[#A6ADBB]">
+                Ocupado
+              </span>
+            </div>
+            <div className=" flex flex-row items-center">
+              <span className="mr-1 block h-4 w-4  rounded-full bg-[#7480FF]">
+                Selecionado
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="flex w-full max-w-[478px] flex-col gap-y-6 rounded-2xl bg-secondary px-4 py-6">
+          <h1 className="text-[20px] font-semibold">
+            Confira os valores do evento
+          </h1>
+          <p>
+            Inteira: {"R$ 100,00"} <br />
+            Meia-entrada: {`R$ 50,00`}
+          </p>
+          <div className="flex flex-col">
+            <TicketKindSelect
+              defaultValue={ticketKind as any}
+              price={data.event.price}
+            />
+          </div>
+          <div>Total: {formattedTotalPrice}</div>
+          {/* TO-DO: implements Checkout Page
+          <Link
+            href="/checkout"
+            className="rounded-lg bg-btn-primary py-4 text-sm font-semibold uppercase text-btn-primary text-center hover:bg-[#fff]"
+          >
+            Ir para pagamento
+          </Link> */}
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default SpotsLayoutPage;

--- a/src/app/services/spots/SpotsService.ts
+++ b/src/app/services/spots/SpotsService.ts
@@ -1,0 +1,24 @@
+import { AxiosInstance } from "axios";
+import { axiosInstance } from "@/config/AxiosInstance";
+import {
+  EventWithSpotsDto,
+  buildEventWithSpotsDto,
+} from "@/dto/event-with-spots/EventWithSpotsDto";
+
+export class SpotsService {
+  private axiosInstance: AxiosInstance = axiosInstance;
+
+  constructor(private eventId: string) {
+    this.eventId = eventId;
+  }
+
+  private async fetchSpots(): Promise<EventWithSpotsDto> {
+    return await this.axiosInstance
+      .get(`/events/${this.eventId}/spots`)
+      .then((response) => buildEventWithSpotsDto(response.data));
+  }
+
+  fetchSportsQuery() {
+    return { queryKey: ["fetchSpots"], queryFn: this.fetchSpots };
+  }
+}

--- a/src/components/SpotSeat/SpotSeat.tsx
+++ b/src/components/SpotSeat/SpotSeat.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { selectSpotAction, unselectSpotAction } from "@/app/actions";
+
+type SpotSeatProps = {
+  spotId: string;
+  spotLabel: string;
+  eventId: string;
+  selected: boolean;
+  disabled: boolean;
+}
+
+export const SpotSeat = ({
+  spotId,
+  spotLabel,
+  eventId,
+  selected,
+  disabled,
+}: SpotSeatProps) => {
+  return (
+    <div className="flex">
+      <input
+        type="checkbox"
+        name={`spots`}
+        id={`spot-${spotId}`}
+        className="peer hidden"
+        value={spotId}
+        disabled={disabled}
+        defaultChecked={selected}
+        onChange={async (event) => {
+          event.target.checked
+            ? await selectSpotAction(eventId, spotId)
+            : await unselectSpotAction(spotId);
+        }}
+      />
+      <label
+        htmlFor={`spot-${spotId}`}
+        className="m-1 h-6 w-6 cursor-pointer select-none
+          rounded-full bg-[#00A96E] py-1 text-center
+          text-[10px] text-black
+          peer-checked:bg-[#7480FF]
+          peer-disabled:cursor-default
+          peer-disabled:bg-[#A6ADBB]
+          "
+      >
+        {spotLabel}
+      </label>
+    </div>
+  );
+};

--- a/src/dto/event-with-spots/EventWithSpotsDto.ts
+++ b/src/dto/event-with-spots/EventWithSpotsDto.ts
@@ -1,0 +1,57 @@
+import { buildEventDto, EventDto, RemoteEvent } from "../events/EventDto";
+import { buildSpotDto, RemoteSpot, SpotDto } from "../spots/SpotDto";
+
+type RemoteEventWithSpots = {
+  event: RemoteEvent;
+  spots: RemoteSpot[];
+};
+
+export class EventWithSpotsDto {
+  event: EventDto;
+  spots: SpotDto[];
+
+  constructor(
+    private readonly remoteEvent: RemoteEvent,
+    private readonly remoteSpots: RemoteSpot[]
+  ) {
+    this.event = buildEventDto(this.remoteEvent);
+    this.spots = this.remoteSpots.map(buildSpotDto);
+  }
+
+  rowLetters(): string[] {
+    return this.spots.map((spot) => spot.name[0]);
+  }
+
+  spotsGroupedByRow(): { row: string; spots: SpotDto[] }[] {
+    return this.rowLetters()
+      .filter((row, index) => this.rowLetters().indexOf(row) === index)
+      .map((row) => {
+        return {
+          row,
+          spots: [
+            ...this.spots
+              .filter((spot) => spot.name[0].startsWith(row))
+              .sort((a, b) => {
+                const aNumber = parseInt(a.name.slice(1));
+                const bNumber = parseInt(b.name.slice(1));
+
+                if (aNumber < bNumber) {
+                  return -1;
+                }
+
+                if (aNumber > bNumber) {
+                  return 1;
+                }
+
+                return 0;
+              }),
+          ],
+        };
+      });
+  }
+}
+
+export const buildEventWithSpotsDto = ({
+  event,
+  spots,
+}: RemoteEventWithSpots) => new EventWithSpotsDto(event, spots);

--- a/src/dto/events/EventDto.ts
+++ b/src/dto/events/EventDto.ts
@@ -1,4 +1,4 @@
-type RemoteEvent = {
+export type RemoteEvent = {
   id: string;
   name: string;
   organization: string;

--- a/src/dto/spots/SpotDto.ts
+++ b/src/dto/spots/SpotDto.ts
@@ -1,0 +1,20 @@
+export type RemoteSpot = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+export class SpotDto {
+  constructor(public id: string, public name: string, public status: string) {
+    this.id = id;
+    this.name = name;
+    this.status = status;
+  }
+
+  spotLabel() {
+    return this.name.slice(1);
+  }
+}
+
+export const buildSpotDto = ({ id, name, status }: RemoteSpot) =>
+  new SpotDto(id, name, status);

--- a/src/hooks/useFetchSpots/useFetchSpots.ts
+++ b/src/hooks/useFetchSpots/useFetchSpots.ts
@@ -1,0 +1,8 @@
+import { useQuery } from "@tanstack/react-query";
+import { SpotsService } from "@/app/services/spots/SpotsService";
+
+export const useFetchSpots = (eventId: string) => {
+  const spotsService = new SpotsService(eventId);
+
+  return useQuery(spotsService.fetchSportsQuery());
+};


### PR DESCRIPTION
### Why is this pull request necessary?
- We need to have a page to display all available and disabled spots of an specific event, so that the user can select the spots he want and know the value that he will pay

### What changes does this pull request add?
- Add spot service
- Add server actions functions
- Add spot seat component
- Add spot dto
- Add event with spots dto
- Add fetch spots hook
- Add ticket kind select component
- Add event spots page