### PR TITLE
Add exemple of revalidate cache route

### DIFF
--- a/src/app/ap/events/[eventId]/revalidate/route.ts
+++ b/src/app/ap/events/[eventId]/revalidate/route.ts
@@ -1,0 +1,30 @@
+// Exemplo cache sob demanda
+// Teria que usar o fetch e não o React Query
+
+import { revalidateTag } from "next/cache";
+import { NextRequest } from "next/server";
+
+type PageRouterProps = {
+  params: { eventId: string };
+};
+
+export function POST(_: NextRequest, { params: { eventId } }: PageRouterProps) {
+  // Re-valida caches onde o request fetch possui como tag os valores de parametro
+  // Ex:
+  // await fetch(`${process.env.GOLANG_API_URL}/events/${eventId}`, {
+  //   headers: {
+  //     "apikey": process.env.GOLANG_API_TOKEN as string
+  //   },
+  //   cache: "no-store",
+  //   next: {
+  //     tags: [`events/${eventId}`],
+  //   }
+  // });
+  //
+  // revalidateTag(`events/${eventId}`);
+
+  revalidateTag("events");
+  revalidateTag(`events/${eventId}`);
+
+  return new Response(null, { status: 204 });
+}


### PR DESCRIPTION
### Why is this pull request necessary?
- If we want to revalidate the cache created by nest on the call of the api we need to create a route for that, but we need to use node fetch function so this is just an exemple

### What changes does this pull request add?
- Add exemple of route to revalidate cache